### PR TITLE
Fixes issue where points remaining would display NaN.

### DIFF
--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -53,8 +53,11 @@ const PointShare = props => {
     }
   }, [teamPoints, authState]);
 
+  // Change points remaining display if inputs are valid
   useEffect(() => {
-    setTotalPoints(100 - calculateInputSum());
+    if (typeof calculateInputSum() === 'number') {
+      setTotalPoints(100 - calculateInputSum());
+    }
     // eslint-disable-next-line
   }, [points]);
 


### PR DESCRIPTION
# Description

Fixes issue where points remaining would display NaN if user types characters into input. Now the points remaining won't change until it verifies that the inputs are correct. Inputs will auto-correct when user leaves the input.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [X] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [X] No
- [ ] Not necessary

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts
